### PR TITLE
Check scaling within test-stat and miqcp projection

### DIFF
--- a/R/iqr_milp.R
+++ b/R/iqr_milp.R
@@ -97,8 +97,12 @@ iqr_milp <- function(Y,
   stopifnot(all.equal(n, n_Z))
   stopifnot(all.equal(n, n_Phi))
 
-  # Ensure that there are some exogeneous variables
-  stopifnot(p_D > 0)
+  # If there are no endogeneous variables, return quantile regression results:
+  if (p_D == 0) {
+    qr <- quantreg::rq(Y ~ X - 1, tau = tau)
+    out <- qr
+    return(out)
+  }
 
   # Create vector of 1s
   ones <- rep(1, n)

--- a/R/iqr_milp.R
+++ b/R/iqr_milp.R
@@ -99,6 +99,8 @@ iqr_milp <- function(Y,
 
   # If there are no endogeneous variables, return quantile regression results:
   if (p_D == 0) {
+    msg <- paste("p_D is 0 -- running QR instead of IQR MILP...")
+    send_note_if(msg, TRUE, warning)
     qr <- quantreg::rq(Y ~ X - 1, tau = tau)
     out <- qr
     return(out)

--- a/R/line_confint.R
+++ b/R/line_confint.R
@@ -158,6 +158,7 @@ line_confint <- function(index,
   stopifnot(is.numeric(beta_null))
   stopifnot(is.numeric(step_size))
   stopifnot(step_size > 0)
+  # TODO: return beta_null, stopping_tolerance, initial step_size
 
   send_note_if(paste0("left bound: ", bounds[1]), show_progress, message)
   send_note_if(paste0("right bound: ", bounds[2]), show_progress, message)
@@ -327,6 +328,7 @@ line_confint <- function(index,
     # save results in CSV
     utils::write.csv(results, log_path)
     # remove files save during while loop
+    # TODO: add option to concatenate these files instead of removing them
     file.remove(list.files(log_dir, pattern = "counter", full.names = T))
   }
 

--- a/R/miqcp_proj.R
+++ b/R/miqcp_proj.R
@@ -155,7 +155,7 @@ miqcp_proj <- function(projection_index,
   stopifnot(length(projection_index) == 1) # we project on axis of only one coefficient
   stopifnot(round(projection_index) == projection_index) # must be integer
   if (endogeneous) {
-    stopifnot(projection_index < p_D)
+    stopifnot(projection_index <= p_D)
   } else {
     stopifnot(any(projection_index %in% beta_X_indices))
   }

--- a/R/preprocess_iqr_milp.R
+++ b/R/preprocess_iqr_milp.R
@@ -101,6 +101,8 @@ preprocess_iqr_milp <- function(Y,
 
   # If there are no endogeneous variables, return quantile regression results:
   if (p_D == 0) {
+    msg <- paste("p_D is 0 -- running QR instead of IQR MILP...")
+    send_note_if(msg, TRUE, warning)
     qr <- quantreg::rq(Y ~ X - 1, tau = tau)
     out$final_fit <- qr
     return(out)

--- a/R/preprocess_iqr_milp.R
+++ b/R/preprocess_iqr_milp.R
@@ -84,6 +84,9 @@ preprocess_iqr_milp <- function(Y,
                                 show_iterations = FALSE,
                                 LogFileExt = ".log",
                                 ...) {
+
+  out <- list() # Initialize list of results to return
+
   # Start the clock
   clock_start <- Sys.time()
 
@@ -96,8 +99,12 @@ preprocess_iqr_milp <- function(Y,
   p_X <- ncol(X)
   p_Z <- ncol(Z)
 
-  # Ensure that there are some endogeneous variables
-  stopifnot(p_D > 0)
+  # If there are no endogeneous variables, return quantile regression results:
+  if (p_D == 0) {
+    qr <- quantreg::rq(Y ~ X - 1, tau = tau)
+    out$final_fit <- qr
+    return(out)
+  }
 
   # Determine preliminary residuals
   if (p_X == 0) {
@@ -179,7 +186,6 @@ preprocess_iqr_milp <- function(Y,
   elapsed_time <- difftime(clock_end, clock_start, units = "mins")
 
   # Return results
-  out <- list()
   out$final_fit <- fit
   out$time <- elapsed_time
   out$O_neg <- O_neg

--- a/R/test_stat.R
+++ b/R/test_stat.R
@@ -71,6 +71,8 @@
 #'  "Powell" (default) to use the Powell estimator or
 #'  "Gaussian" to use a Gaussian kernel; only used when
 #'  \code{homoskedasticity} is FALSE
+#' @param residuals Residuals from IQR MILP program; if NULL (default), use
+#'  naive residuals from quantile regression
 #' @param show_progress If TRUE (default), sends progress messages during
 #'  execution (boolean); also passed to \code{FUN}
 #' @param FUN Either \code{preprocess_iqr_milp} (default) or \code{iqr_milp}
@@ -87,6 +89,7 @@ test_stat <- function(beta_D_null,
                       B = NULL,
                       orthogonalize_statistic = FALSE,
                       homoskedasticity = FALSE,
+                      residuals = NULL,
                       kernel = "Powell",
                       show_progress = TRUE,
                       FUN = preprocess_iqr_milp,
@@ -201,7 +204,13 @@ test_stat <- function(beta_D_null,
     # regression to define a_hat.
     a_hat <- short_iqr_result$dual
   }
-  resid <- short_iqr_result$resid
+  if (is.null(residuals)) {
+    resid <- short_iqr_result$resid
+    out$resid <- resid
+  } else {
+    resid <- residuals
+    out$resid <- resid
+  }
 
   # Obtain \hat{b}
   b_hat <- a_hat - (1 - tau)

--- a/R/test_stat.R
+++ b/R/test_stat.R
@@ -233,6 +233,7 @@ test_stat <- function(beta_D_null,
     tmp_c <- 1.5 * (stats::dnorm(stats::qnorm(tau)) ^ 2)
     tmp_d <- 2 * (stats::qnorm(tau) ^ 2) + 1
     hs <- tmp_a * tmp_b * ((tmp_c / tmp_d) ^ (1 / 3))
+    out$hs <- hs
     if (kernel == "powell") {
       bw <- hs
       # TODO: double-check whether this is correct

--- a/R/test_stat.R
+++ b/R/test_stat.R
@@ -263,7 +263,8 @@ test_stat <- function(beta_D_null,
   # Construct L_n or Q_n depending on |J| + |K| == or != 1
   # Compute p-value
   if (cardinality_J + cardinality_K == 1) {
-    test_stat <- S_n / sqrt(tau * (1 - tau) * t(B_tilde) %*% B_tilde)
+    # TODO: check that the "/ n" in denominator is correct
+    test_stat <- S_n / sqrt(tau * (1 - tau) * t(B_tilde) %*% B_tilde / n)
     p_val <- 2 * (1 - stats::pnorm(abs(test_stat)))
   } else {
     M_n <- (1 / n) * t(B_tilde) %*% B_tilde

--- a/R/test_stat.R
+++ b/R/test_stat.R
@@ -182,14 +182,25 @@ test_stat <- function(beta_D_null,
   }
   out$short_iqr <- short_iqr_result
 
-  if (short_iqr_result$status != "OPTIMAL") {
-    warning(paste("Short IQR Status:", short_iqr_result$status))
+  # To get a_hat under full-vector inference (i.e., cardinality_J == p_D),
+  # we run a quantile regression, not the usual IQR MILP procedure.
+  # Hence, we don't need to print "status" or "objval" if we are in
+  # the full-vector setting because quantile regression doesn't return such
+  # results.
+  if (cardinality_J != p_D) {
+    if (short_iqr_result$status != "OPTIMAL") {
+      warning(paste("Short IQR Status:", short_iqr_result$status))
+    }
+    if (short_iqr_result$status == "TIME_LIMIT" | short_iqr_result$objval != 0) {
+      message(paste("Short IQR Objective Value:", short_iqr_result$objval))
+      return(out)
+    }
+    a_hat <- short_iqr_result$a
+  } else {
+    # In full-vector inference, we use the dual variables of quantile
+    # regression to define a_hat.
+    a_hat <- short_iqr_result$dual
   }
-  if (short_iqr_result$status == "TIME_LIMIT" | short_iqr_result$objval != 0) {
-    message(paste("Short IQR Objective Value:", short_iqr_result$objval))
-    return(out)
-  }
-  a_hat <- short_iqr_result$a
   resid <- short_iqr_result$resid
 
   # Obtain \hat{b}


### PR DESCRIPTION
In the univariate test-stat, there was a missing 1/n in the square root of the denominator.
As a result, the line search was taking forever to complete and yielded strange results.

If p_D = 0 (which may happen if we concentrate out all the endogenous variables during full-vector inference procedures), then instead of solving IQR MILP, we solve the quantile regression.